### PR TITLE
fix: Target loaders toward build/ directory when fetching submodule data

### DIFF
--- a/src/server/format-version-loader.ts
+++ b/src/server/format-version-loader.ts
@@ -28,15 +28,28 @@ function formatVersion(version: string): FormatVersion {
   };
 }
 
-export function getFormatVersions(): FormatVersion[] {
-  const ebdPath = join(process.cwd(), "static", "ebd");
+function tryReadDir(path: string) {
   try {
-    return readdirSync(ebdPath, { withFileTypes: true })
-      .filter((dirent) => dirent.isDirectory())
-      .map((dirent) => formatVersion(dirent.name))
-      .sort((a, b) => b.code.localeCompare(a.code)); // descending order
-  } catch (error) {
-    console.error("No format version directories available.", error);
+    return readdirSync(path, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+}
+
+// fetch submodule data from either /static/ebd (sveltekit "dev server") or /build/ebd (sveltekit "preview")
+export function getFormatVersions(): FormatVersion[] {
+  const staticPath = join(process.cwd(), "static", "ebd");
+  const buildPath = join(process.cwd(), "build", "ebd");
+
+  const dirents = tryReadDir(staticPath) || tryReadDir(buildPath);
+
+  if (!dirents) {
+    console.error("submodule data not found.");
     return [];
   }
+
+  return dirents
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => formatVersion(dirent.name))
+    .sort((a, b) => b.code.localeCompare(a.code));
 }


### PR DESCRIPTION
fixes

<img width="1131" alt="Screenshot 2024-10-28 at 19 28 19" src="https://github.com/user-attachments/assets/fdba9d7c-8a88-4045-8f0a-a4ed9d5941f1">

```shell
Error loading EBDs Error: ENOENT: no such file or directory, scandir '.../entscheidungsbaumdiagramm/static/ebd'
    at readdirSync (node:fs:1502:26)
    at getEbds (file://.../entscheidungsbaumdiagramm/.svelte-kit/output/server/chunks/format-version-loader.js:7:28)
    at load (file://.../entscheidungsbaumdiagramm/.svelte-kit/output/server/entries/pages/_layout.server.ts.js:4:16)
    at load_server_data (file://.../entscheidungsbaumdiagramm/.svelte-kit/output/server/index.js:554:42)
    at file://.../entscheidungsbaumdiagramm/.svelte-kit/output/server/index.js:2023:24 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: '.../entscheidungsbaumdiagramm/static/ebd'
}
```