### PR TITLE
docs: Add more descriptions regarding how to test the project locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ npm run build && npx http-server ./build
 
 This starts an HTTP server at http://127.0.0.1:8080, providing a local view roughly similar to how Azure will render the project.
 
-### auth0 authentication
+### Auth0 authentication
 
 > [!NOTE]
 > During local development, authentication is currently not required. Instead, a dummy account `local@development.com` will be already logged in at both local dev server startup as well as build preview.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ $ npm run format # formats the whole project (prettier)
 $ npm run test # runs E2E tests (playwright) assuming the dev server is up and running
 ```
 
+to serve the built built site locally, run
+
+```sh
+$ npm run build && npx http-server ./build
+```
+
+to start a http server at http://127.0.0.1:8080, providing a local view roughly similar to how Azure will render the project.
+
 ### auth0 authentication
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ![Prettier status badge](https://github.com/Hochfrequenz/ebd.hochfrequenz.de/workflows/Formatting/badge.svg)
 ![PlayWright status badge](https://github.com/Hochfrequenz/ebd.hochfrequenz.de/workflows/E2E-Testing/badge.svg)
 
-### setting up development environment
+### Setting up development environment
 
-make sure you have the latest version of [node](https://nodejs.org/en) installed (recommended via node version manager [nvm](https://github.com/nvm-sh/nvm)).
+Make sure you have the latest version of [node](https://nodejs.org/en) installed (recommended via node version manager [nvm](https://github.com/nvm-sh/nvm)).
 
 ```sh
 $ npm install
@@ -20,13 +20,13 @@ $ npm run format # formats the whole project (prettier)
 $ npm run test # runs E2E tests (playwright) assuming the dev server is up and running
 ```
 
-to serve the built built site locally, run
+To serve the built site locally, run
 
 ```sh
 $ npm run build && npx http-server ./build
 ```
 
-to start a http server at http://127.0.0.1:8080, providing a local view roughly similar to how Azure will render the project.
+This starts an HTTP server at http://127.0.0.1:8080, providing a local view roughly similar to how Azure will render the project.
 
 ### auth0 authentication
 


### PR DESCRIPTION
its more reliant than running `npm run build && npm run preview` since sveltekits built-in preview does handle dynamic routing differently and may not necessarily match the actual result when deployed to azure