### PR TITLE
refactor: Combine [formatversion] and [ebd] slug into one dynamic route

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "format": "prettier '**/*.{svelte,js,jsx,ts,tsx,html,css,scss,json,yml,md}' --write",
     "format:check": "prettier '**/*.{svelte,js,jsx,ts,tsx,html,css,scss,json,yml,md}' --check",
-    "lint": "eslint 'src/**/*.{js,ts,svelte}'",
+    "lint": "eslint 'src/**/*.{js,ts,svelte}' --fix",
     "postinstall": "npx playwright install",
     "test": "npx playwright test"
   },

--- a/src/lib/features/ebd-form-header.svelte
+++ b/src/lib/features/ebd-form-header.svelte
@@ -48,8 +48,6 @@
     const formattedEbd = ebd.replace(/_/g, "");
     if (formatVersion && ebd) {
       goto(`${base}/ebd/${formatVersion}/${formattedEbd}`);
-    } else if (formatVersion) {
-      goto(`${base}/ebd/${formatVersion}`);
     }
   }
 </script>

--- a/src/routes/ebd/+page.svelte
+++ b/src/routes/ebd/+page.svelte
@@ -21,7 +21,7 @@
   function handleEbdSelect(event: CustomEvent<string>) {
     selectedEbd = event.detail;
     if (selectedFormatVersion && selectedEbd) {
-      const formattedEbd = selectedEbd.replace("_", "");
+      const formattedEbd = selectedEbd.replace(/_/g, "");
       goto(`${base}/ebd/${selectedFormatVersion}/${formattedEbd}`);
     }
   }

--- a/src/routes/ebd/[...ebd]/+layout.svelte
+++ b/src/routes/ebd/[...ebd]/+layout.svelte
@@ -7,7 +7,7 @@
   $: ({ formatVersions, ebds } = $page.data);
   $: params = $page.params.ebd?.split("/") || [];
   $: formatVersion = params[0];
-  $: ebd = params[1];
+  $: ebdKey = params[1];
 </script>
 
 <div class="flex flex-col h-full">
@@ -15,7 +15,7 @@
     {formatVersions}
     {ebds}
     currentFormatVersion={formatVersion}
-    currentEbd={ebd}
+    currentEbd={ebdKey}
   />
   <div class="flex-grow overflow-hidden">
     <slot />

--- a/src/routes/ebd/[...ebd]/+layout.svelte
+++ b/src/routes/ebd/[...ebd]/+layout.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  import "../../../../app.scss";
+  import "../../../app.scss";
 
   import { page } from "$app/stores";
   import { EbdFormHeader } from "$lib";
 
   $: ({ formatVersions, ebds } = $page.data);
-  $: ({ formatVersion, ebd } = $page.params);
+  $: params = $page.params.ebd?.split("/") || [];
+  $: formatVersion = params[0];
+  $: ebd = params[1];
 </script>
 
 <div class="flex flex-col h-full">

--- a/src/routes/ebd/[...ebd]/+page.svelte
+++ b/src/routes/ebd/[...ebd]/+page.svelte
@@ -13,14 +13,14 @@
 
   $: params = $page.params.ebd?.split("/") || [];
   $: formatVersion = params[0];
-  $: ebd = params[1];
+  $: ebdKey = params[1];
 
   async function loadSvg() {
-    if (!mounted || !formatVersion || !ebd) return;
+    if (!mounted || !formatVersion || !ebdKey) return;
 
     isLoading = true;
     error = null;
-    const ebdFile = `E_${ebd.slice(1)}`;
+    const ebdFile = `E_${ebdKey.slice(1)}`;
     const ebdPath = `${base}/ebd/${formatVersion}/${ebdFile}.svg`;
 
     try {
@@ -46,7 +46,7 @@
     }
   }
 
-  $: if (mounted && formatVersion && ebd) {
+  $: if (mounted && formatVersion && ebdKey) {
     loadSvg();
   }
 
@@ -56,7 +56,7 @@
 
   onMount(() => {
     mounted = true;
-    if (formatVersion && ebd) {
+    if (formatVersion && ebdKey) {
       loadSvg();
     }
   });

--- a/src/routes/ebd/[...ebd]/+page.svelte
+++ b/src/routes/ebd/[...ebd]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   /* eslint-disable svelte/no-at-html-tags */
-
   import { onMount } from "svelte";
 
   import { base } from "$app/paths";
@@ -12,10 +11,12 @@
   let error: string | null = null;
   let mounted = false;
 
-  $: ({ formatVersion, ebd } = $page.params);
+  $: params = $page.params.ebd?.split("/") || [];
+  $: formatVersion = params[0];
+  $: ebd = params[1];
 
   async function loadSvg() {
-    if (!mounted) return;
+    if (!mounted || !formatVersion || !ebd) return;
 
     isLoading = true;
     error = null;
@@ -31,6 +32,7 @@
     } catch (err) {
       console.error(`error loading svg: ${err}`);
       svgContent = "";
+      error = err instanceof Error ? err.message : "Unknown error";
     } finally {
       isLoading = false;
     }

--- a/src/routes/ebd/[...ebd]/+page.svelte
+++ b/src/routes/ebd/[...ebd]/+page.svelte
@@ -32,7 +32,6 @@
     } catch (err) {
       console.error(`error loading svg: ${err}`);
       svgContent = "";
-      error = err instanceof Error ? err.message : "Unknown error";
     } finally {
       isLoading = false;
     }


### PR DESCRIPTION
makes way more sense to combine these two routes due to the way they are accessed;
i also hope this makes setting up the fallback of dynamic routes after deployment easier