### PR TITLE
chore: allow Vite serving from `static` to load Roboto for dev server 

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,4 +10,9 @@ export default defineConfig({
       $src: path.resolve("./src"),
     },
   },
+  server: {
+    fs: {
+      allow: ["./static"],
+    },
+  },
 });


### PR DESCRIPTION
fixes

```sh
The request url "<...>/entscheidungsbaumdiagramm/static/Roboto-Regular.ttf" is outside of Vite serving allow list.
- <...>/entscheidungsbaumdiagramm/src/lib
- <...>/entscheidungsbaumdiagramm/src/routes
- <...>/entscheidungsbaumdiagramm/.svelte-kit
- <...>/entscheidungsbaumdiagramm/src
- <...>/entscheidungsbaumdiagramm/node_modules
Refer to docs https://vite.dev/config/server-options.html#server-fs-allow for configurations and more details.
```