### PR TITLE
fix: use equal padding of `gap-4` between header elements

### DIFF
--- a/src/lib/components/shared/header.svelte
+++ b/src/lib/components/shared/header.svelte
@@ -38,14 +38,14 @@
       aria-label="Global"
     >
       <div class="flex items-center gap-4">
-        <div class="flex-none">
+        <div class="flex pt-1">
           <a href="{base}/" title="landingpage">
             <IconLogo size={23} />
           </a>
+          <span class="text-xl text-black/70 whitespace-nowrap">
+            Entscheidungsbaumdiagramme
+          </span>
         </div>
-        <span class="text-xl text-black/70 whitespace-nowrap">
-          Entscheidungsbaumdiagramme
-        </span>
         <div class="min-w-[245px] flex items-center pl-1 pb-1">
           <FormatVersionSelect
             {formatVersions}


### PR DESCRIPTION
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/c75d5cfa-f6e2-4fc0-a0b0-20cf47b2fd9d" />