### PR TITLE
feat: add export button component for `PUML` download

### DIFF
--- a/src/lib/components/features/export-puml-button.svelte
+++ b/src/lib/components/features/export-puml-button.svelte
@@ -12,12 +12,35 @@
   let cooldownTimer: ReturnType<typeof setTimeout>;
   let remainingSeconds = 0;
   let downloadStarted = false;
+  let isPumlAvailable = false;
 
   onMount(() => {
     return () => {
       if (cooldownTimer) clearTimeout(cooldownTimer);
     };
   });
+
+  // check if PUML file is availabe (roughly 75% of SVGs have an associated PUML file)
+  $: if (currentFormatVersion && currentEbd) {
+    checkPumlAvailability();
+  }
+
+  async function checkPumlAvailability() {
+    if (!currentFormatVersion || !currentEbd) {
+      isPumlAvailable = false;
+      return;
+    }
+
+    const pumlPath = `${base}/ebd/${currentFormatVersion}/${currentEbd}.puml`;
+
+    try {
+      const response = await fetch(pumlPath, { method: "HEAD" });
+      isPumlAvailable = response.ok;
+    } catch (err) {
+      console.error(`Error checking PUML availability: ${err}`);
+      isPumlAvailable = false;
+    }
+  }
 
   // 5 seconds cooldown to prevent download from being spammed
   function startCooldownTimer() {
@@ -38,7 +61,13 @@
   }
 
   async function handleExport() {
-    if (isDisabled || !isExportReady || !currentFormatVersion || !currentEbd)
+    if (
+      isDisabled ||
+      !isExportReady ||
+      !currentFormatVersion ||
+      !currentEbd ||
+      !isPumlAvailable
+    )
       return;
 
     isExportReady = false;
@@ -69,16 +98,18 @@
   }
 </script>
 
-<button
-  on:click={handleExport}
-  class="flex flex-row items-center gap-2 rounded-full bg-secondary text-[16px] py-3 px-5 text-black/70 transition-opacity duration-200 whitespace-nowrap min-w-[150px] justify-center"
-  class:opacity-30={isDisabled || !isExportReady}
-  class:cursor-not-allowed={!isExportReady}
-  disabled={isDisabled || !isExportReady}
->
-  {#if downloadStarted}
-    {remainingSeconds} s
-  {:else}
-    <IconDownload /> Export PUML
-  {/if}
-</button>
+{#if isPumlAvailable}
+  <button
+    on:click={handleExport}
+    class="flex flex-row items-center gap-2 rounded-full bg-secondary text-[16px] py-3 px-5 text-black/70 transition-opacity duration-200 whitespace-nowrap min-w-[150px] justify-center"
+    class:opacity-30={isDisabled || !isExportReady}
+    class:cursor-not-allowed={!isExportReady}
+    disabled={isDisabled || !isExportReady}
+  >
+    {#if downloadStarted}
+      {remainingSeconds} s
+    {:else}
+      <IconDownload /> Export PUML
+    {/if}
+  </button>
+{/if}

--- a/src/lib/components/features/export-puml-button.svelte
+++ b/src/lib/components/features/export-puml-button.svelte
@@ -42,20 +42,20 @@
       return;
 
     isExportReady = false;
-    const ebdPath = `${base}/ebd/${currentFormatVersion}/${currentEbd}.svg`;
+    const pumlPath = `${base}/ebd/${currentFormatVersion}/${currentEbd}.puml`;
 
     try {
-      const response = await fetch(ebdPath);
+      const response = await fetch(pumlPath);
       if (!response.ok) {
         throw new Error(`http error: ${response.status}`);
       }
-      const svgContent = await response.text();
+      const pumlContent = await response.text();
 
-      const blob = new Blob([svgContent], { type: "image/svg+xml" });
+      const blob = new Blob([pumlContent], { type: "text/plain" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `${currentFormatVersion}-${currentEbd}.svg`;
+      a.download = `${currentFormatVersion}_${currentEbd}.puml`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
@@ -63,7 +63,7 @@
 
       startCooldownTimer();
     } catch (err) {
-      console.error(`error exporting svg: ${err}`);
+      console.error(`error exporting puml: ${err}`);
       isExportReady = true;
     }
   }
@@ -79,6 +79,6 @@
   {#if downloadStarted}
     {remainingSeconds} s
   {:else}
-    <IconDownload /> Export SVG
+    <IconDownload /> Export PUML
   {/if}
 </button>

--- a/src/lib/components/features/export-svg-button.svelte
+++ b/src/lib/components/features/export-svg-button.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  import { base } from "$app/paths";
+  import { IconDownload } from "$lib/components";
+
+  export let currentFormatVersion: string = "";
+  export let currentEbd: string = "";
+  export let isDisabled: boolean = false;
+
+  let isExportReady = true;
+  let cooldownTimer: ReturnType<typeof setTimeout>;
+  let remainingSeconds = 0;
+  let downloadStarted = false;
+
+  onMount(() => {
+    return () => {
+      if (cooldownTimer) clearTimeout(cooldownTimer);
+    };
+  });
+
+  // 5 seconds cooldown to prevent download from being spammed
+  function startCooldownTimer() {
+    remainingSeconds = 5;
+    downloadStarted = true;
+
+    const updateTimer = () => {
+      if (remainingSeconds > 0) {
+        remainingSeconds--;
+        cooldownTimer = setTimeout(updateTimer, 1000);
+      } else {
+        isExportReady = true;
+        downloadStarted = false;
+      }
+    };
+
+    cooldownTimer = setTimeout(updateTimer, 1000);
+  }
+
+  async function handleExport() {
+    if (isDisabled || !isExportReady || !currentFormatVersion || !currentEbd)
+      return;
+
+    isExportReady = false;
+    const ebdPath = `${base}/ebd/${currentFormatVersion}/${currentEbd}.svg`;
+
+    try {
+      const response = await fetch(ebdPath);
+      if (!response.ok) {
+        throw new Error(`http error: ${response.status}`);
+      }
+      const svgContent = await response.text();
+
+      const blob = new Blob([svgContent], { type: "image/svg+xml" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${currentFormatVersion}_${currentEbd}.svg`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      startCooldownTimer();
+    } catch (err) {
+      console.error(`error exporting svg: ${err}`);
+      isExportReady = true;
+    }
+  }
+</script>
+
+<button
+  on:click={handleExport}
+  class="flex flex-row items-center gap-2 rounded-full bg-secondary text-[16px] py-3 px-5 text-black/70 transition-opacity duration-200 whitespace-nowrap min-w-[150px] justify-center"
+  class:opacity-30={isDisabled || !isExportReady}
+  class:cursor-not-allowed={!isExportReady}
+  disabled={isDisabled || !isExportReady}
+>
+  {#if downloadStarted}
+    {remainingSeconds} s
+  {:else}
+    <IconDownload /> Export SVG
+  {/if}
+</button>

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -17,7 +17,8 @@ export { default as IconPlant } from "$lib/components/shared/icon-plant.svelte";
 // features
 export { default as EbdInput } from "$lib/components/features/ebd-input.svelte";
 export { default as EbdNavigation } from "$lib/components/features/ebd-navigation.svelte";
-export { default as ExportButton } from "$lib/components/features/export-button.svelte";
+export { default as ExportPumlButton } from "$lib/components/features/export-puml-button.svelte";
+export { default as ExportSvgButton } from "$lib/components/features/export-svg-button.svelte";
 export { default as FilterChapterSelect } from "$lib/components/features/filter-chapter-select.svelte";
 export { default as FilterPanel } from "$lib/components/features/filter-panel.svelte";
 export { default as FilterRoleSelect } from "$lib/components/features/filter-role-select.svelte";

--- a/src/routes/ebd/+page.svelte
+++ b/src/routes/ebd/+page.svelte
@@ -6,7 +6,8 @@
   import {
     AuthButton,
     ErrorMsg,
-    ExportButton,
+    ExportPumlButton,
+    ExportSvgButton,
     Header,
     SvgContainer,
   } from "$lib/components";
@@ -224,7 +225,12 @@
   >
     <svelte:fragment slot="actions">
       <div class="flex gap-4">
-        <ExportButton
+        <ExportSvgButton
+          currentFormatVersion={selectedFormatVersion}
+          currentEbd={selectedEbd}
+          isDisabled={!selectedFormatVersion || !selectedEbd || !svgContent}
+        />
+        <ExportPumlButton
           currentFormatVersion={selectedFormatVersion}
           currentEbd={selectedEbd}
           isDisabled={!selectedFormatVersion || !selectedEbd || !svgContent}


### PR DESCRIPTION
equivalent to `svg` download.
<img width="510" alt="image" src="https://github.com/user-attachments/assets/783fa261-78a1-48ce-9f67-a6d9a7d3e915" />