### PR TITLE
fix: prevent landing page title from overflowing

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,7 +18,9 @@
 
 <section class="bg-primary flex-grow flex items-center justify-center">
   <div class="rounded-3xl bg-secondary p-12 shadow-md w-1/3">
-    <h1 class="text-3xl text-black/70 pb-5">Entscheidungsbaumdiagramme</h1>
+    <h1 class="text-3xl text-black/70 pb-5 break-all">
+      Entscheidungsbaumdiagramme
+    </h1>
     <h2
       class="flex text-lg border-b-2 border-primary text-black/70 pb-3 mb-5 uppercase"
     >


### PR DESCRIPTION
<img width="487" alt="image" src="https://github.com/user-attachments/assets/97249db1-8b97-436c-8a6a-fd8705aa83d4" />