### PR TITLE
fix: prevent URL updates during the initial component mount

### DIFF
--- a/src/lib/components/shared/header.svelte
+++ b/src/lib/components/shared/header.svelte
@@ -38,8 +38,8 @@
   export let metadata: Record<string, Record<string, MetaData>> = {};
   export let onSectionSelect: (ebdCode: string) => void;
 
-  let hasForatVersionSelected = selectedFormatVersion !== "";
-  $: hasForatVersionSelected = selectedFormatVersion !== "";
+  let hasFormatVersionSelected = selectedFormatVersion !== "";
+  $: hasFormatVersionSelected = selectedFormatVersion !== "";
 
   function handlePanelToggle(event: PanelToggleEvent) {
     dispatch("panelToggle", event.detail);
@@ -72,9 +72,9 @@
           <div class="min-w-[298px] flex items-center">
             <EbdInput
               ebds={ebdList}
-              disabled={!hasForatVersionSelected}
+              disabled={!hasFormatVersionSelected}
               selectedEbdCode={selectedEbd}
-              formatVersionChanged={hasForatVersionSelected}
+              formatVersionChanged={hasFormatVersionSelected}
               onSelect={onEbdSelect}
             />
           </div>

--- a/src/routes/ebd/+page.svelte
+++ b/src/routes/ebd/+page.svelte
@@ -73,7 +73,6 @@
     const rolesParam = searchParams.get("rolle");
     const chaptersParam = searchParams.get("chapter");
 
-    // Only override if URL parameters exist
     if (formatVersion) selectedFormatVersion = formatVersion;
     if (ebd) selectedEbd = ebd;
     if (rolesParam) {

--- a/src/routes/ebd/+page.svelte
+++ b/src/routes/ebd/+page.svelte
@@ -32,6 +32,7 @@
   let svgContent = "";
   let isLoading = false;
   let error: boolean = false;
+  let isInitialLoad = true;
 
   $: if (selectedFormatVersion) {
     ebdList = filterEbds(
@@ -42,6 +43,9 @@
   }
 
   function updateURL() {
+    // make sure URL updates only if the initial load phase is over
+    if (isInitialLoad) return;
+
     const params = new URLSearchParams();
 
     if (selectedFormatVersion) {
@@ -69,6 +73,7 @@
     const rolesParam = searchParams.get("rolle");
     const chaptersParam = searchParams.get("chapter");
 
+    // Only override if URL parameters exist
     if (formatVersion) selectedFormatVersion = formatVersion;
     if (ebd) selectedEbd = ebd;
     if (rolesParam) {
@@ -89,6 +94,8 @@
     if (selectedFormatVersion && selectedEbd) {
       await loadSvg();
     }
+
+    isInitialLoad = false;
   });
 
   async function loadSvg() {


### PR DESCRIPTION
sonst updated die URL beim refresh bevor die Seite geladen ist, was dazu führt, dass der Inhalt (svg/error page) nicht mehr lädt und der EBD input resetted