### PR TITLE
fix: add typefaces to tailwind config to prevent tailwind from using system default fonts

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,15 @@ export default {
         weichesschwarz: "#25241D",
       },
     },
+    fontFamily: {
+      sans: ["Roboto", "Helvetica", "Arial", "sans-serif"],
+      mono: ["Roboto Mono", "monospace"],
+    },
+    fontWeight: {
+      normal: 400,
+      medium: 500,
+      bold: 700,
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
<img width="357" alt="image" src="https://github.com/user-attachments/assets/5f25180b-7987-4409-9279-9dd428060e23" />

jetzt passt es; vorher hat tailwind die default system/browser typeface verwendet