### PR TITLE
chore: add FV2410 to enable AHBesser deeplinks

### DIFF
--- a/src/lib/components/features/format-version-select.svelte
+++ b/src/lib/components/features/format-version-select.svelte
@@ -16,8 +16,8 @@
     const cutoffDate = new Date(2025, 5, 6);
 
     if (currentDate < cutoffDate) {
-      const fv2404 = formatVersions.find((v) => v.code === "FV2404");
-      return fv2404?.code || "";
+      const fv2410 = formatVersions.find((v) => v.code === "FV2410");
+      return fv2410?.code || "";
     } else {
       const fv2504 = formatVersions.find((v) => v.code === "FV2504");
       return fv2504?.code || "";

--- a/src/server/ebd-loader.ts
+++ b/src/server/ebd-loader.ts
@@ -11,12 +11,6 @@ let ebdFiles: Record<string, string[]> | null = null;
 let ebdFullName: Record<string, EbdNameExtended[]> | null = null;
 let ebdMetadata: Record<string, Record<string, MetaData>> | null = null;
 
-// mapping of FVs where the BDEW skipped EBD related updates
-const skippedFormatVersionToInsteadFormatVersionMap: Record<string, string> = {
-  // key = skipped format version; value = previous (still valid) format version
-  FV2410: "FV2404",
-};
-
 // fetches EBD files and associated metadata
 function getEbds(): Record<string, string[]> {
   if (ebdFiles) return ebdFiles;
@@ -30,10 +24,6 @@ function getEbds(): Record<string, string[]> {
       .map((dirent) => dirent.name);
 
     for (const formatVersion of formatVersions) {
-      if (skippedFormatVersionToInsteadFormatVersionMap[formatVersion]) {
-        continue;
-      }
-
       const versionPath = join(staticPath, formatVersion);
       const files = readdirSync(versionPath);
 

--- a/src/server/format-version-loader.ts
+++ b/src/server/format-version-loader.ts
@@ -19,17 +19,9 @@ const formatVersionMap: Record<string, string> = {
   "2510": "Oktober 2025",
 };
 
-// mapping of FVs where the BDEW skipped EBD related updates
-const skippedFormatVersionToInsteadFormatVersionMap: Record<string, string> = {
-  // key = skipped format version; value = previous (still valid) format version
-  FV2410: "FV2404",
-};
-
 function formatVersion(version: string): FormatVersion {
   const formattedVersion = version.startsWith("FV") ? version : `FV${version}`;
-  const mappedVersion =
-    skippedFormatVersionToInsteadFormatVersionMap[formattedVersion] ||
-    formattedVersion;
+  const mappedVersion = formattedVersion;
   const versionNumber = mappedVersion.replace("FV", "");
   const formatVersionDate = formatVersionMap[versionNumber];
 
@@ -50,13 +42,6 @@ export function getFormatVersions(): FormatVersion[] {
       .filter((dirent) => dirent.isDirectory())
       .map((dirent) => formatVersion(dirent.name))
       .filter((version) => {
-        if (
-          Object.keys(skippedFormatVersionToInsteadFormatVersionMap).includes(
-            version.code,
-          )
-        ) {
-          return false;
-        }
         if (uniqueFormatVersion.has(version.code)) {
           return false;
         }


### PR DESCRIPTION
since AHBesser does not provide AHBs of FV2404 or older anymore