### PR TITLE
chore: add and set FV2604 as current FV

### DIFF
--- a/src/lib/components/features/format-version-select.svelte
+++ b/src/lib/components/features/format-version-select.svelte
@@ -10,17 +10,17 @@
 
   import { onMount } from "svelte";
 
-  // set default format version to FV2410 if currentDate < 06.06.2025
+  // set default format version to FV2604 if currentDate < 01.10.2026
   function getDefaultFormatVersion(): string {
     const currentDate = new Date();
     const cutoffDate = new Date(2025, 10, 1);
 
     if (currentDate < cutoffDate) {
-      const fv2504 = formatVersions.find((v) => v.code === "FV2504");
-      return fv2504?.code || "";
+      const fv2604 = formatVersions.find((v) => v.code === "FV2604");
+      return fv2604?.code || "";
     } else {
-      const fv2510 = formatVersions.find((v) => v.code === "FV2510");
-      return fv2510?.code || "";
+      const fv2610 = formatVersions.find((v) => v.code === "FV2610");
+      return fv2610?.code || "";
     }
   }
 

--- a/src/lib/components/features/format-version-select.svelte
+++ b/src/lib/components/features/format-version-select.svelte
@@ -13,7 +13,7 @@
   // set default format version to FV2604 if currentDate < 01.10.2026
   function getDefaultFormatVersion(): string {
     const currentDate = new Date();
-    const cutoffDate = new Date(2025, 10, 1);
+    const cutoffDate = new Date(2026, 10, 1);
 
     if (currentDate < cutoffDate) {
       const fv2604 = formatVersions.find((v) => v.code === "FV2604");

--- a/src/server/format-version-loader.ts
+++ b/src/server/format-version-loader.ts
@@ -17,6 +17,7 @@ const formatVersionMap: Record<string, string> = {
   "2410": "Oktober 2024",
   "2504": "Juni 2025",
   "2510": "Oktober 2025",
+  "2604": "April 2026",
 };
 
 // older FVs < FV2404 that are excluded from <selects>


### PR DESCRIPTION
ist in meinen Augen sinnvoll, FV2604 als default zu setzen, da die Konzeptionen für Formatanpassungen jetzt in vollem Gange sind