### PR TITLE
fix: Add format version '2610' for October 2026

### DIFF
--- a/src/server/format-version-loader.ts
+++ b/src/server/format-version-loader.ts
@@ -18,6 +18,7 @@ const formatVersionMap: Record<string, string> = {
   "2504": "Juni 2025",
   "2510": "Oktober 2025",
   "2604": "April 2026",
+  "2610": "Oktober 2026"
 };
 
 // older FVs < FV2404 that are excluded from <selects>

--- a/src/server/format-version-loader.ts
+++ b/src/server/format-version-loader.ts
@@ -18,7 +18,7 @@ const formatVersionMap: Record<string, string> = {
   "2504": "Juni 2025",
   "2510": "Oktober 2025",
   "2604": "April 2026",
-  "2610": "Oktober 2026"
+  "2610": "Oktober 2026",
 };
 
 // older FVs < FV2404 that are excluded from <selects>


### PR DESCRIPTION
fixes the undefined here: 
<img width="573" height="280" alt="{CD8FE3F5-95C6-443D-9950-F45DE1D898B5}" src="https://github.com/user-attachments/assets/0672530b-18f7-421f-abfb-6f8d1c3ee1cc" />
