### PR TITLE
fix: remove the dead Kontakt link from the footer

### DIFF
--- a/src/lib/components/shared/footer.svelte
+++ b/src/lib/components/shared/footer.svelte
@@ -73,12 +73,6 @@
           target="_blank"
           href="https://www.hochfrequenz.de/impressum/">Impressum</a
         >
-        <span> | </span>
-        <a
-          class="mx-2"
-          target="_blank"
-          href="https://www.hochfrequenz.de/kontakt/">Kontakt</a
-        >
       </p>
     </div>
 


### PR DESCRIPTION
`https://www.hochfrequenz.de/kontakt/` returns **HTTP 404** — the page no longer exists, so
the footer's `Kontakt` link is dead. This removes it.

**Nothing replaces it:** contact details already live on the Impressum page, whose own page
title is *"Impressum | Jetzt Kontakt aufnehmen"*. The `Impressum` link stays, so the
information is still one click away.

The dangling `|` separator that preceded the link is removed too, leaving the remaining
links correctly formed — no doubled and no trailing separator.


## Verification

- `npm run check` (svelte-kit sync + svelte-check) → **0 errors**, 339 files. The 2 warnings
  are pre-existing `tsconfig.json` TS7.0 deprecation notices.
- eslint over `src/**` → clean.
- `npm run format:check` reports style issues in 62 files **including files this PR does not
  touch** — verified pre-existing by stashing this change and re-running: the same 62 files
  were already flagged. Cause is `core.autocrlf=true` checking files out CRLF on Windows while
  Prettier wants LF; `npx prettier footer.svelte | diff -u footer.svelte -` shows only
  line-ending differences, zero content differences. This PR neither introduces nor worsens it.
- No unit or e2e test files exist in the repo, so none were applicable.
- No release-please / git-cliff / semantic-release config and no CHANGELOG.

## Left alone deliberately

`src/lib/components/shared/error-page.svelte:57` contains user-facing prose mentioning a
*"Kontaktformular"*. It is copy, not a link to the 404ing page; rewording is a separate
content decision.

## Context

Found while adding a fifth pill (MaKo-Prozesse) to the cross-app solutions footer in all five
MaKo apps. Design doc: `Hochfrequenz/mako_prozesse` →
`docs/plans/2026-08-11-solutions-footer-design.md`. Related issue filed here: #720
(pill labels fail WCAG AA).

## Related issues filed in this repo

- **#720** — solutions-footer pill labels fail WCAG AA (white on pastel, 1.51–2.55:1), with the
  measured ratios and a note that this repo's `weichesschwarz` token is **not** the brand
  `--weiches-schwarz` (`#25241D` vs `#25141d`)
- **#723** — `error-page.svelte` prose points users at a Kontaktformular that no longer exists
- **#724** — the footer's `Datenschutz`/`Impressum` links miss `rel="noopener noreferrer"`

Design doc: `Hochfrequenz/mako_prozesse` → `docs/plans/2026-08-11-solutions-footer-design.md`
(Hochfrequenz/mako_prozesse#73).
