### PR TITLE
feat: add the Dolmetscher pill to the cross-app solutions footer

### DIFF
--- a/src/lib/components/shared/footer-tools.svelte
+++ b/src/lib/components/shared/footer-tools.svelte
@@ -82,6 +82,21 @@
       >
         MaKo-Prozesse
       </a>
+      <a
+        href="https://dolmetscher.hochfrequenz.de"
+        target="_blank"
+        rel="noopener noreferrer"
+        style="font:14px/22px Roboto, sans-serif; line-height:1.5;"
+        class="flex flex-row items-center rounded-full bg-dolmetscher_primary text-white text-lg px-2 py-1 m-2
+            ring-1
+            ring-black/5
+            hover:ring-black/10
+            transition-all
+            duration-300
+            ease-in-out"
+      >
+        Dolmetscher
+      </a>
     </div>
   </div>
 </footer>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,7 @@ export default {
         ahb_tone: "#ebbec1",
         bedingungsbaum_primary: "#e5bd5c",
         bedingungsbaum_secondary: "#F4E2B9",
+        dolmetscher_primary: "#85cb9c",
         ebd_primary: "#8BA2D7",
         ebd_secondary: "#C2CEE9",
         fristenkalender_primary: "#abdcd3",


### PR DESCRIPTION
Adds a sixth pill — **Dolmetscher** — to the cross-app solutions footer, linking to the Marktnachrichten-Dolmetscher alongside the other apps. The same pill is going into the sibling repos in parallel PRs.

**Stacked on `feat/mako-prozesse-pill`** (the MaKo-Prozesse pill PR), so this diff is only the sixth pill. Review/merge that one first; this retargets to `main` afterwards.

- Label `Dolmetscher` → `https://dolmetscher.hochfrequenz.de`
- Fill `bg-dolmetscher_primary` = `#85cb9c`

## The colour is already upstream — nothing was invented

`#85cb9c` is `--grell-mint` in [companystylesheet](https://github.com/Hochfrequenz/companystylesheet), and it is byte-for-byte the Dolmetscher's own `--color-dolmetscher_primary`. Each app owns a colour family upstream (`rot`, `tuerkis`, `gelb`, `blau`, `lila`, `mint`); mint is the Dolmetscher's, so this pill uses the app's real brand colour rather than an approximation. Added to `tailwind.config.js` in its alphabetical slot, following the file's existing `_primary` convention.

**Unlike the MaKo-Prozesse pill, this one works at merge:** `https://dolmetscher.hochfrequenz.de` returns **200**. There is no domain sequencing gate here.

**16 insertions, 0 deletions.** The existing pills are untouched — not reordered, not relabelled, not refactored into a loop, which would bury a one-pill addition inside a restructure.

## On the label

`Dolmetscher` rather than the full `Marktnachrichten-Dolmetscher`, to keep the row's width economy — the app's own header calls itself "Marktnachrichten Dolmetscher", so if you prefer the full name in the pill, say so and it is a one-word change.

## Accessibility note (pre-existing, not introduced here)

White text on `#85cb9c` measures **1.91:1**, below WCAG AA. That is not specific to this pill — every pill in the row already fails AA (Fristenkalender 1.51:1, Bedingungsbaum 1.78:1, MaKo 2.31:1, EBD 2.55:1, AHB 2.97:1). Flagging it rather than fixing it here: recolouring the row is a design decision across five repos, not a drive-by in a pill addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
